### PR TITLE
feat: 배경 추가, 간격 조정

### DIFF
--- a/src/app/(pages)/band/[band_id]/_components/band_detail.tsx
+++ b/src/app/(pages)/band/[band_id]/_components/band_detail.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 export default function Detail() {
   return (
     <div className='w-full h-full flex justify-center items-center'>
-      <div className='flex justify-center items-start w-full bg-blue-300/30'>
+      <div className='flex justify-center items-start w-full bg-gray-500/30'>
         <div className='flex-1'>
           {/* 상단 섹션 */}
           <div className='flex justify-between items-center p-3'>
@@ -13,17 +13,11 @@ export default function Detail() {
                 <img src='/img/cover.jpg' alt='앨범커버' />
               </div>
               <div className='flex flex-col justify-center'>
-                <div className='text-l'>Hello, Wonderland</div>
-                <div className='text-m'>Lacuna</div>
+                <div className='text-l text-white'>Hello, Wonderland</div>
+                <div className='text-m text-white'>Lacuna</div>
               </div>
             </div>
-
-            {/* 재생 버튼 */}
-            <button className='w-16 h-16 rounded-full bg-black/30'>재생</button>
           </div>
-
-          {/* 하단 재생바 */}
-          <div>재생바</div>
         </div>
       </div>
     </div>

--- a/src/app/(pages)/band/[band_id]/_components/band_video.tsx
+++ b/src/app/(pages)/band/[band_id]/_components/band_video.tsx
@@ -6,9 +6,6 @@ export default function Video() {
   return (
     <div className='w-full h-full flex justify-center items-center'>
       <div className='flex justify-center items-start w-full aspect-[16/9] bg-red-100 relative'>
-        <div className='absolute top-0 z-1'>
-          <BackButton />
-        </div>
         <video
           className='w-full aspect-[16/9] shadow-md'
           controls

--- a/src/app/(pages)/band/[band_id]/page.tsx
+++ b/src/app/(pages)/band/[band_id]/page.tsx
@@ -2,20 +2,24 @@ import React from 'react';
 import Video from '@/app/(pages)/band/[band_id]/_components/band_video';
 import Detail from '@/app/(pages)/band/[band_id]/_components/band_detail';
 import Info from '@/app/(pages)/band/[band_id]/_components/band_info';
+import BackButton from './_components/band_backButton';
+import { BandFinalInfo } from '@/app/_common/interfaces/band-info.interface';
+import { getBandFinalInfo } from '@/app/_common/apis/band-final-info';
 
-export default function bandDetail({
-  params: { id },
-}: {
-  params: { id: string };
-}) {
+export default function bandDetail() {
   return (
     <div>
-      <div className='w-full h-full flex justify-center items-start flex-col gap-1'>
+      <div className='w-full h-full flex justify-center items-start flex-col gap-1 bg-[url("/images/main-background.jpg")]'>
+        <div className='absolute top-0 z-1'>
+          <BackButton />
+        </div>
         <div className='w-full flex-1 flex-col'>
           <Video />
           <Detail />
         </div>
-        <div className='w-full aspect-[3/2] bg-gray-200'>팀 사진</div>
+        <div className=' w-full aspect-[3/2] p-2'>
+          <div className='w-full aspect-[3/2] bg-gray-200'>팀 사진</div>
+        </div>
         <Info />
       </div>
     </div>


### PR DESCRIPTION
배경이랑 간격 조정했습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일**
  - 메인 컨테이너의 배경색이 반투명 파란색에서 반투명 회색으로 변경되었습니다.
  - "Hello, Wonderland"와 "Lacuna" 텍스트가 흰색으로 표시됩니다.
  - 팀 사진 섹션에 패딩과 비율 스타일이 추가되었습니다.
  - 메인 컨테이너에 배경 이미지가 추가되었습니다.

- **버그 수정**
  - 재생 버튼과 재생 바가 제거되었습니다.
  - 영상 위에 표시되던 뒤로가기 버튼이 제거되었습니다.

- **신규 기능**
  - 페이지 상단에 새로운 뒤로가기 버튼이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->