### PR TITLE
fix: next/image error, style: band-detail padding

### DIFF
--- a/src/app/(pages)/(home)/_components/band-card.tsx
+++ b/src/app/(pages)/(home)/_components/band-card.tsx
@@ -26,14 +26,13 @@ export default function BandCard({
       whileTap={{ scale: 0.9 }}
       transition={{ duration: 0.3 }}
     >
-      <Image
+      <img
         ref={dragRef as unknown as React.RefObject<HTMLImageElement>}
         src={finalBandDetail.band.image}
         alt={finalBandDetail.band.name}
-        fill
         className={
           'z-20' +
-          'object-cover rounded-xl cursor-grab' +
+          'size-full object-cover rounded-xl cursor-grab' +
           (isDragging ? ' opacity-0' : '')
         }
       />

--- a/src/app/(pages)/(home)/_components/more-videos.tsx
+++ b/src/app/(pages)/(home)/_components/more-videos.tsx
@@ -32,11 +32,10 @@ export default function MoreVideos({
             }}
           >
             <div className='relative w-25 h-auto flex flex-col justify-center items-start gap-2 overflow-x-auto scrollbar-hide aspect-square'>
-              <Image
+              <img
                 src={item.band.image}
                 alt='more-videos'
-                fill
-                className='object-cover rounded-xl'
+                className='size-full object-cover rounded-xl'
               />
             </div>
             <div className='flex flex-col justify-start items-start gap-1 text-white'>

--- a/src/app/(pages)/(home)/_components/tv-dropzone.tsx
+++ b/src/app/(pages)/(home)/_components/tv-dropzone.tsx
@@ -10,7 +10,7 @@ export default function TVDropZone() {
   const [, dropRef] = useDrop({
     accept: 'VIDEO_THUMB',
     drop: (item: { id: string }) => {
-      router.push(`/videos/${item.id}`);
+      router.push(`/band/${item.id}`);
     },
   });
 
@@ -26,11 +26,10 @@ export default function TVDropZone() {
         marginBottom: 16,
       }}
     >
-      <Image
+      <img
         src={'/images/tv-dropzone.jpg'}
         alt='tv-background'
-        fill
-        className='object-cover'
+        className='size-full object-cover'
       />
     </div>
   );

--- a/src/app/(pages)/band/[band_id]/_components/band_backButton.tsx
+++ b/src/app/(pages)/band/[band_id]/_components/band_backButton.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import Link from 'next/link';
-
+import { ChevronLeft } from 'lucide-react';
 function BackButton() {
   return (
-    <Link href='/final/'>
-      <button className='w-8 h-8 border-2 border-white'>X</button>
+    <Link href='/final'>
+      <button className='size-10 flex justify-center items-center bg-white rounded-full'>
+        <ChevronLeft className='w-6 h-6 text-black' />
+      </button>
     </Link>
   );
 }

--- a/src/app/(pages)/band/[band_id]/_components/band_detail.tsx
+++ b/src/app/(pages)/band/[band_id]/_components/band_detail.tsx
@@ -1,14 +1,22 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 export default function Detail({
-  song_description,
+  song_title,
   album_cover,
   band,
 }: {
-  song_description: string;
+  song_title: string;
   album_cover: string;
   band: string;
 }) {
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  if (!isMounted && !album_cover) return null;
+
   return (
     <div className='w-full h-full relative flex justify-center items-center'>
       {/* 🔽 배경 그라데이션 레이어 */}
@@ -20,10 +28,10 @@ export default function Detail({
           <div className='flex justify-between items-center p-3'>
             <div className='flex items-center gap-4'>
               <div className='w-16'>
-                <img src={album_cover} alt='앨범커버' />
+                {album_cover && <img src={album_cover} alt='앨범커버' />}
               </div>
               <div className='flex flex-col justify-center'>
-                <div className='text-l text-white'>{song_description}</div>
+                <div className='text-l text-white'>{song_title}</div>
                 <div className='text-m text-white'>{band}</div>
               </div>
             </div>

--- a/src/app/(pages)/band/[band_id]/_components/band_info.tsx
+++ b/src/app/(pages)/band/[band_id]/_components/band_info.tsx
@@ -8,8 +8,8 @@ export default function Info({
   song_description: string;
 }) {
   return (
-    <div className='w-full h-full flex justify-center items-center'>
-      <div className='flex justify-center w-full h-24 p-8 bg-black-300/50 text-white'>
+    <div className='px-4 w-full h-fit flex justify-center items-center pb-20 rounded-b-4xl'>
+      <div className='flex justify-center w-full h-fit pt-8 bg-black-300/50 text-white'>
         {band}
         {song_description}
       </div>

--- a/src/app/(pages)/band/[band_id]/_components/band_video.tsx
+++ b/src/app/(pages)/band/[band_id]/_components/band_video.tsx
@@ -1,13 +1,14 @@
 import React, { Suspense } from 'react';
-import Detail from './band_detail';
-import BackButton from './band_backButton';
-import { Band } from '@/app/_common/interfaces/band-info.interface';
-import ReactPlayer from 'react-player';
+import dynamic from 'next/dynamic';
+
+const ReactPlayer = dynamic(() => import('react-player'), {
+  ssr: false, // 서버에선 빈 자리에 fallback(없음)만 찍힘
+});
 
 export default function Video({ url }: { url: string }) {
   return (
     <div className='w-full h-full flex justify-center items-center'>
-      <div className='flex justify-center items-start w-full aspect-[16/9] bg-red-100 relative'>
+      <div className='flex justify-center items-center w-full aspect-[16/9] bg-red-100 relative'>
         <Suspense fallback={null}>
           <ReactPlayer url={url} controls preload='none' />
         </Suspense>

--- a/src/app/(pages)/band/[band_id]/page.tsx
+++ b/src/app/(pages)/band/[band_id]/page.tsx
@@ -27,38 +27,30 @@ export default function bandDetail() {
     void fetchVideoDetail();
   }, [param.band_id]);
 
-  const ReactPlayer = dynamic(() => import('react-player'), {
-    ssr: false, // 서버에선 빈 자리에 fallback(없음)만 찍힘
-  });
-
   return (
-    <div>
-      <div className='w-full min-h-screen flex justify-center items-start flex-col gap-1 bg-[url("/images/main-background.jpg")]'>
-        <div className='absolute top-0 z-1'>
-          <BackButton />
-        </div>
-        <div className='w-full flex-1 flex-col'>
-          <Video url={video?.url ?? ''} />
-          <Detail
-            song_description={video?.song_description ?? ''}
-            band={video?.band.name ?? ''}
-            album_cover={video?.album_cover ?? ''}
-          />
-        </div>
-        <div className=' w-full aspect-[3/2] p-2'>
-          <div>
-            <img
-              className='w-full aspect-[3/2] rounded-[5%]'
-              src={video?.band.image ?? ''}
-              alt='프로필'
-            />
-          </div>
-        </div>
-        <Info
-          band={video?.band.description ?? ''}
-          song_description={video?.song_description ?? ''}
+    <div className='w-full flex justify-center items-start flex-col gap-1 bg-[url("/images/main-background.jpg")] rounded-4xl'>
+      <div className='absolute top-0 z-1 p-2'>
+        <BackButton />
+      </div>
+      <div className='w-full flex-1 flex-col rounded-t-4xl'>
+        <Video url={video?.url ?? ''} />
+        <Detail
+          song_title={video?.song_title ?? ''}
+          band={video?.band.name}
+          album_cover={video?.album_cover ?? ''}
         />
       </div>
+      <div className=' w-full aspect-[3/2] pt-2'>
+        <img
+          className='w-full aspect-[3/2] rounded-[5%]'
+          src={video?.band.image}
+          alt='프로필'
+        />
+      </div>
+      <Info
+        band={video?.band.description ?? ''}
+        song_description={video?.song_description ?? ''}
+      />
     </div>
   );
 }

--- a/src/app/(pages)/final/_components/ArtistCard.tsx
+++ b/src/app/(pages)/final/_components/ArtistCard.tsx
@@ -38,12 +38,11 @@ export default function ArtistCard({
         className='w-[80px] h-[80px] relative cursor-pointer'
         onClick={handleClick}
       >
-        <Image
+        <img
           ref={dragRef as unknown as React.RefObject<HTMLImageElement>}
           src={image}
           alt={name}
-          fill
-          className='object-cover rounded-md'
+          className='size-full object-cover rounded-md'
         />
       </div>
       <h3 className='text-center text-xs font-semibold break-keep'>{name}</h3>

--- a/src/app/(pages)/final/_components/ArtistGrid.tsx
+++ b/src/app/(pages)/final/_components/ArtistGrid.tsx
@@ -19,7 +19,7 @@ export default function ArtistGrid({
   votedIds,
 }: ArtistGridProps) {
   return (
-    <div className='grid grid-cols-1 sm:grid-cols-1 md:grid-cols-3 gap-4 justify-items-center'>
+    <div className='grid grid-cols-1 sm:grid-cols-1 md:grid-cols-3 gap-4 justify-items-center pb-20'>
       {artists.map(artist => (
         <ArtistCard
           key={artist.id}

--- a/src/app/(pages)/final/page.tsx
+++ b/src/app/(pages)/final/page.tsx
@@ -59,7 +59,7 @@ export default function Final() {
 
   return (
     <div
-      className='p-8'
+      className='p-8 rounded-4xl'
       style={{
         backgroundImage: 'url(/images/final-background.png)',
         backgroundSize: 'cover',

--- a/src/app/(pages)/mypage/_components/fake-alert.tsx
+++ b/src/app/(pages)/mypage/_components/fake-alert.tsx
@@ -25,7 +25,7 @@ export function FakeAlert() {
         <AlertDialogHeader>
           <AlertDialogTitle>Fake!</AlertDialogTitle>
           <AlertDialogDescription>
-            <Image
+            <img
               src='/images/fake-key.jpeg'
               alt='mypage-background'
               width={300}

--- a/src/app/(pages)/mypage/_components/profile-info.tsx
+++ b/src/app/(pages)/mypage/_components/profile-info.tsx
@@ -26,14 +26,12 @@ export default function ProfileInfo() {
       />
       <div className='absolute inset-0 bg-gradient-to-t from-black via-transparent to-transparent rounded-b-xl pointer-events-none'></div>
       <div className='px-8 py-2 absolute bottom-2  w-full h-auto flex items-end justify-start gap-4'>
-        <Image
+        <img
           src={
             'https://velog.velcdn.com/images/bokdol11859/post/7410acc4-0834-4e64-ba57-6a22173c261c/image.png'
           }
           alt='profile'
-          width={100}
-          height={100}
-          className='rounded-2xl'
+          className='size-[100px] rounded-2xl'
         />
         <div className='flex flex-col gap-2 text-primary-yellow'>
           <h2>{user.name}</h2>

--- a/src/app/(pages)/preliminary/_components/pre-suspense-component.tsx
+++ b/src/app/(pages)/preliminary/_components/pre-suspense-component.tsx
@@ -55,11 +55,10 @@ export default function PreSuspenseComponent() {
           key={item.band.id}
           className='relative w-full h-screen snap-start flex items-center justify-center'
         >
-          <Image
+          <img
             src='/images/preliminary-background.jpg'
             alt='preliminary-background'
-            fill
-            className='object-fill rounded-4xl'
+            className='size-full object-fill rounded-4xl'
           />
           <section className='relative w-full h-full flex items-center justify-center rounded-4xl'>
             <Suspense fallback={<div>Loading...</div>}>

--- a/src/app/_common/components/gnb.tsx
+++ b/src/app/_common/components/gnb.tsx
@@ -49,12 +49,10 @@ const GNB = () => {
                 )}
                 strokeWidth={3}
               />
-              <Image
+              <img
                 src={`/images/gnb-background.jpg`}
                 alt={item.href}
-                width={40}
-                height={40}
-                className='absolute top-0 left-0'
+                className='size-10 absolute top-0 left-0'
               />
             </Link>
           ))}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일**
    - 여러 컴포넌트에서 Next.js의 이미지 컴포넌트를 표준 HTML `<img>` 태그로 교체하여 이미지 렌더링 방식을 변경하였습니다.
    - 다양한 컴포넌트와 페이지에서 CSS 클래스가 수정되어, 이미지와 컨테이너의 크기, 패딩, 모서리 둥글기 등 스타일이 개선되었습니다.
    - 뒤로가기 버튼이 X 텍스트에서 그래픽 아이콘(왼쪽 화살표)으로 변경되어 시각적 일관성이 향상되었습니다.
- **버그 수정**
    - 앨범 커버 이미지가 없는 경우 렌더링을 방지하여 빈 이미지 표시 문제를 해결하였습니다.
- **기능 개선**
    - 동영상 플레이어가 클라이언트에서만 동적으로 로드되도록 변경되어 페이지 성능이 최적화되었습니다.
    - 일부 컴포넌트의 prop 명칭이 직관적으로 변경되어 정보 전달이 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->